### PR TITLE
Fix Financisto CSV-Import

### DIFF
--- a/app/src/main/java/com/ivy/wallet/logic/csv/CSVImporter.kt
+++ b/app/src/main/java/com/ivy/wallet/logic/csv/CSVImporter.kt
@@ -73,7 +73,7 @@ class CSVImporter(
 
         val rows = csvReader.readAll()
             .map { it.toList() }
-        var rowsCount = rows.size
+        val rowsCount = rows.size
 
         newCategoryColorIndex = 0
         newAccountColorIndex = 0
@@ -124,7 +124,7 @@ class CSVImporter(
         }
 
         return ImportResult(
-            rowsFound = rowsCount,
+            rowsFound = rowsCount - joinResult.mergedCount,
             transactionsImported = transactions.size,
             accountsImported = accounts.size - initialAccountsCount,
             categoriesImported = categories.size - initialCategoriesCount,
@@ -241,7 +241,9 @@ class CSVImporter(
             normalizedType.contains("income") -> TransactionType.INCOME
             normalizedType.contains("expense") -> TransactionType.EXPENSE
             normalizedType.contains("transfer") -> TransactionType.TRANSFER
-            else -> null
+            // Default to Expense because Financisto messed up its CSV Export
+            // and mixes it with another (ignored) column
+            else -> TransactionType.EXPENSE
         }
     }
 

--- a/app/src/main/java/com/ivy/wallet/logic/csv/CSVMapper.kt
+++ b/app/src/main/java/com/ivy/wallet/logic/csv/CSVMapper.kt
@@ -193,7 +193,7 @@ class CSVMapper {
 
         transformTransaction = { transaction, _, csvAmount ->
             transaction.copy(
-                //Idk, never seen a sample CSV from Financisto
+                // Financisto exports expenses with a negative sign and incoming as positive values
                 type = if (csvAmount > 0 && transaction.type == TransactionType.EXPENSE) {
                     TransactionType.INCOME
                 } else {


### PR DESCRIPTION
@ILIYANGERMANOV thanks for the review of #201 and the refactoring! Seems mostly very reasonable to me :)

I fixed two more issues:
- When merging two rows, we need to decrement the `rowsFound` field in the `ImportResult`. Otherwise for each merged transaction, one will show as failed in the results.

- I just noticed, that Financisto messed up its CSV exports and puts the location in the same field as where it specifies whether it was a transfer or not. Thus this field may contain arbitrary data which caused the previous implementation to fail. Note that this may produce unexpected results if the location name contains "transfer", "expense" or "income", but there seems no easy way to avoid this and it seems very unlikely that a location contains these strings.
I hope this does not affect the other importers, if it does another solution is required...

This is one sample CSV which should cover most cases which I used for testing: https://pastebin.com/XZRpdfsc

(And I just sent you a message on LinkedIN ;))