### PR TITLE
Add a warning about submitting PRs only to develop branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ compact **[Contributors Guide](https://github.com/ILIYANGERMANOV/ivy-wallet/blob
 to begin.
 
 TL;DR:
-- Submit pull requests for bug fixes / code improvements
+- Submit pull requests for bug fixes / code improvements to the `develop` branch
 - Implement and submit PRs for opened issues
 - Report (or fix) bugs/glitches 
 - Create new issues to give us ideas and feedback


### PR DESCRIPTION
## Pull Request (PR) Checklist

Please check if your pull request fulfills the following requirements:

- [x] The PR is submitted to the `develop` branch.
- [x] I've read the **[Contribution Guidelines](https://github.com/ILIYANGERMANOV/ivy-wallet/blob/main/CONTRIBUTING.md)**.

## Pull Request Type

- [x] Documentation (clarifying comments, KDoc)

## What's changed?

- Now in TL;DR about contributing it says that it is necessary to submit PRs only to develop branch