### PR TITLE
Replacing hard-coded strings in applocked UI

### DIFF
--- a/app/src/main/java/com/ivy/wallet/ui/applocked/AppLockedScreen.kt
+++ b/app/src/main/java/com/ivy/wallet/ui/applocked/AppLockedScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -46,7 +47,7 @@ fun BoxWithConstraintsScope.AppLockedScreen(
                 .background(UI.colors.medium, UI.shapes.rFull)
                 .padding(vertical = 12.dp)
                 .padding(horizontal = 32.dp),
-            text = "APP LOCKED",
+            text = stringResource(R.string.app_locked),
             style = UI.typo.b2.style(
                 fontWeight = FontWeight.ExtraBold,
             )
@@ -66,7 +67,7 @@ fun BoxWithConstraintsScope.AppLockedScreen(
         Spacer(Modifier.weight(1f))
 
         Text(
-            text = "Authenticate to enter the app",
+            text = stringResource(R.string.authenticate_text),
             style = UI.typo.b2.style(
                 fontWeight = FontWeight.SemiBold,
                 color = Gray
@@ -80,7 +81,7 @@ fun BoxWithConstraintsScope.AppLockedScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            text = "Unlock",
+            text = stringResource(R.string.unlock),
             textStyle = UI.typo.b2.style(
                 color = White,
                 fontWeight = FontWeight.Bold,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,2 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_locked">APP LOCKED</string>
+    <string name="authenticate_text">Authenticate to enter the app</string>
+    <string name="unlock">Unlock</string>
 </resources>


### PR DESCRIPTION
## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `develop` branch.
- [x] I've read the **[Contribution Guidelines](https://github.com/ILIYANGERMANOV/ivy-wallet/blob/main/CONTRIBUTING.md)**.
- [x] The code builds and is tested on an actual Android device.
- [x] I confirm that I've run the code locally and everything works as expected.
- [ ] I confirm that I've run Ivy Wallet's UI tests (`androidTest`) and all tests are passing
  successfully.

_Important: Don't worry if you experience flaky UI tests. Just re-run the failed ones again and if they pass => it's all good!_

_Put an `x` in the boxes that apply._
- [x] Demo: Checking checkbox using `[x]`


## Pull Request Type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, new lines, etc.)
- [x] Refactoring (no functional changes, renaming)
- [ ] Small improvement (fix typo, UI fine-tune, change color or something small)
- [ ] Gradle Build related changes
- [ ] Dependencies update (updating libraries)
- [ ] Documentation (clarifying comments, KDoc)
- [ ] Tests (Unit, Integration, UI tests)
- [ ] Other (please describe):

_Put an `x` in the boxes that apply._


## Does this PR closes any GitHub Issues?
Check **[Ivy Wallet Issues](https://github.com/ILIYANGERMANOV/ivy-wallet/issues)**.
- Closes #N/A (type issue number here)


## What's changed?
Describe with a few bullets **what's new:**
- Added strings to the strings.xml file
- Inserted the new strings inside the applocked UI instead of hard-coded strings

## How to run Ivy Wallet's UI tests (`androidTest`)
**Connect Android Emulator**
- Pixel 5 API 29+ AVD emulator _(recommended)_
- Pixel 3XL API 29+ AVD emulator _(recommended)_
- Large screen physical device _(might also work)_

**Method 1: Android Studio UI**
- Find `com (androidTest)` package
- Right click
- `Run 'Tests in 'com''`

_Note: If you've checked "Compact Middle Packages" the option will appear as `com.ivy.wallet (androidTest)`._

**Method 2: Gradle Wrapper**
- `chmod +x gradlew` (Linux)
- `./gradlew connectedDebugAndroidTest`

**Method 3: Fastlane**
- Install Ruby 2.7
- `bundle install`
- `bundle exec fastlane ui_tests`
